### PR TITLE
Randomization fixes, CI fix, optimizations, and fix for crashing (?)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vcpkg"]
 	path = vcpkg
-	url = https://github.com/Microsoft/vcpkg.git
+	url = https://github.com/microsoft/vcpkg.git

--- a/src/RandomItems.cpp
+++ b/src/RandomItems.cpp
@@ -212,6 +212,7 @@ void RandomItems::GiveRandomItem()
     }
 
     if(m_SpawnInWorld) {
+        Logger::Info("Spawning in world: {}", s_PropPair.first);
         ZSpatialEntity* s_HitmanSpatial = s_LocalHitman.m_ref.QueryInterface<ZSpatialEntity>();
 
         const auto s_Scene = Globals::Hitman5Module->m_pEntitySceneContext->m_pScene;
@@ -263,6 +264,7 @@ void RandomItems::GiveRandomItem()
 
         Functions::ZItemSpawner_RequestContentLoad->Call(s_ItemSpawner);
     }  else {
+        Logger::Info("Adding to inventory: {} {}", s_PropPair.first, s_PropPair.second.ToString());
         const TArray<TEntityRef<ZCharacterSubcontroller>>* s_Controllers = &s_LocalHitman.m_pInterfaceRef->m_pCharacter.m_pInterfaceRef->m_rSubcontrollerContainer.m_pInterfaceRef->m_aReferencedControllers;
         auto* s_Inventory = static_cast<ZCharacterSubcontrollerInventory*>(s_Controllers->operator[](6).m_pInterfaceRef);
 

--- a/src/RandomItems.cpp
+++ b/src/RandomItems.cpp
@@ -212,7 +212,6 @@ void RandomItems::GiveRandomItem()
     }
 
     if(m_SpawnInWorld) {
-        Logger::Info("Spawning in world: {}", s_PropPair.first);
         ZSpatialEntity* s_HitmanSpatial = s_LocalHitman.m_ref.QueryInterface<ZSpatialEntity>();
 
         const auto s_Scene = Globals::Hitman5Module->m_pEntitySceneContext->m_pScene;
@@ -264,7 +263,6 @@ void RandomItems::GiveRandomItem()
 
         Functions::ZItemSpawner_RequestContentLoad->Call(s_ItemSpawner);
     }  else {
-        Logger::Info("Adding to inventory: {} {}", s_PropPair.first, s_PropPair.second.ToString());
         const TArray<TEntityRef<ZCharacterSubcontroller>>* s_Controllers = &s_LocalHitman.m_pInterfaceRef->m_pCharacter.m_pInterfaceRef->m_rSubcontrollerContainer.m_pInterfaceRef->m_aReferencedControllers;
         auto* s_Inventory = static_cast<ZCharacterSubcontrollerInventory*>(s_Controllers->operator[](6).m_pInterfaceRef);
 

--- a/src/RandomItems.h
+++ b/src/RandomItems.h
@@ -5,6 +5,7 @@
 #include <Glacier/SGameUpdateEvent.h>
 #include <Glacier/ZResource.h>
 #include <Glacier/ZResourceID.h>
+#include <random>
 
 class RandomItems : public IPluginInterface {
 public:
@@ -17,7 +18,6 @@ private:
     void OnFrameUpdate(const SGameUpdateEvent& p_UpdateEvent);
     void LoadRepositoryProps();
     void GiveRandomItem();
-    std::pair<const std::string, ZRepositoryID> GetRepositoryPropFromIndex(int s_Index);
     std::string ConvertDynamicObjectValueTString(const ZDynamicObject& p_DynamicObject);
 
 private:
@@ -29,7 +29,10 @@ private:
     bool m_IncludeItemsWithoutTitle = false;
     float m_HitmanItemPosition[3] = { 0, 1, 0 };
     TResourcePtr<ZTemplateEntityFactory> m_RepositoryResource;
-    std::multimap<std::string, ZRepositoryID> m_RepositoryProps;
+    std::vector<std::pair<std::string, ZRepositoryID>> m_RepositoryProps;
+
+    std::mt19937 m_RandomGenerator;
+    std::uniform_int_distribution<size_t> m_Distribution;
 };
 
 DEFINE_ZHM_PLUGIN(RandomItems)


### PR DESCRIPTION
### Randomization:
I noticed while playing the game that the mod had a tendency to start going through items in very predictable ways, sometimes in alphabetical order!
After a quick skim of the code I found many issues with how randomization was being done, so I made a new approach using C++'s `<random>` library which doesn't suffer from the same issues:

- `std::rand()` is a simple linear congruential generator, way too simple for this mod's needs. I replaced it with C++'s `std::mt19937` Mersenne Twister algorithm, which is much more sophisticated and produces high-quality random numbers over very long periods of time.
- `std::srand()` was being called every time every time `GiveRandomItem()` was executed. Because `std::time(nullptr)` has a resolution of one second, if you set the timeout to less than one second (e.g., 0.1 seconds) the function will be seeded with the same value each time and you will receive the same item 10 times. Fixed by instead seeding only once using `std::random_device` in `OnEngineInitialized()`, which produces non-deterministic seeds. 
- Using the modulo operator to constrain the output of `std::rand()` introduces a bias towards specific items if `m_RepositoryProps.size()` is not a perfect divisor of `RAND_MAX + 1`. Fixed by using `std::uniform_int_distribution` instead.

### Optimization:

- The mod currently generates a random index, then iterates from the beginning of the items map to find the item at that index every single time `GetRepositoryPropFromIndex()` is called. This is a really inefficient linear search with O(N) time complexity (where N is amount of items). `std::multimap` is optimized for lookups by key rather than index. I improved on this by using `std::vector` instead and retrieving items in a single, direct access operation. This means that the `GetRepositoryPropFromIndex()` function is no longer needed and the time complexity is now always O(1).

### Other fixes:

- You forgot to clear the previous item list in `LoadRepositoryProps`, which can lead to item lists that skew randomization and bloat memory usage (for example, if the user spams the "Rebuild Item Pool" button, the list would have a lot of duplicated items). Fixed by running `m_RepositoryProps.clear()` before doing anything else.
- The old code calculated `std::rand() % m_RepositoryProps.size()`, which would lead to a division by zero if `LoadRepositoryProps` failed for any reason and the size was 0. Now, the size is checked before creating the distribution.
- I noticed the mod tended to make the game very prone to crashing if it was allowed to spawn thousands of items. I'm not entirely sure if this is what causes it to be honest but I changed `EDisposalType` to `DISPOSAL_DESTROY` instead of `DISPOSAL_HIDE`. I couldn't get it to crash the game again after this change so I assume this fixed it and I didn't see anything weird happen in-game either.
- CI was broken because the gitlink to vcpkg wasn't present. Added one.